### PR TITLE
Update julia compat entry + bug fix

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "ReportMetrics"
 uuid = "c1654acf-408b-4272-96ce-66c258df8a6c"
 authors = ["Charles Kawczynski <kawczynski.charles@gmail.com>"]
-version = "0.1.0"
+version = "0.1.1"
 
 [deps]
 Coverage = "a2441757-f6aa-5fb2-8edb-039e3f45d037"
@@ -11,4 +11,4 @@ PrettyTables = "08abe8d2-0d0c-5749-adfa-8a2ac140af0d"
 [compat]
 Coverage = "1.4"
 PrettyTables = "1.3"
-julia = "1.7"
+julia = "1"

--- a/bors.toml
+++ b/bors.toml
@@ -1,0 +1,9 @@
+status = [
+  "ci 1.7.0 - ubuntu-latest",
+  "ci 1.7.0 - windows-latest",
+  "ci 1.7.0 - macOS-latest",
+]
+delete_merged_branches = true
+timeout_sec = 10800
+block_labels = [ "do-not-merge-yet" ]
+cut_body_after = "<!--"

--- a/src/ReportMetrics.jl
+++ b/src/ReportMetrics.jl
@@ -153,7 +153,7 @@ function report_allocs(;
 
     data = map(zip(filenames, linenumbers)) do (filename, linenumber)
         label = xtick_name(filename_only(filename), linenumber)
-        name = basename(pkg_dir_from_file(dirname(filename)))
+        # name = basename(pkg_dir_from_file(dirname(filename)))
         url = ""
         # TODO: incorporate URLS into table
         # if haskey(pkg_urls, name)


### PR DESCRIPTION
This PR:
 - Updates the julia compat entry
 - Adds a bors toml file
 - Avoids calling `pkg_dir_from_file`, which is missing edge cases
 - bumps the patch version number