### PR TITLE
Use more robust and hackable input args

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "ReportMetrics"
 uuid = "c1654acf-408b-4272-96ce-66c258df8a6c"
 authors = ["Charles Kawczynski <kawczynski.charles@gmail.com>"]
-version = "0.1.1"
+version = "0.2.0"
 
 [deps]
 Coverage = "a2441757-f6aa-5fb2-8edb-039e3f45d037"

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@
 [bors-url]: https://app.bors.tech/repositories/41363
 
 
-A package for reporting allocations, which builds ontop of [Coverage.jl](https://github.com/JuliaCI/Coverage.jl)
+A package for reporting metrics (e.g., allocations), which builds ontop of [Coverage.jl](https://github.com/JuliaCI/Coverage.jl)
 
 ## Example
 
@@ -24,10 +24,13 @@ See our test suite for an example usage:
 
 ```julia
 import ReportMetrics
+ma_dir = ReportMetrics.mod_dir(ReportMetrics)
 ReportMetrics.report_allocs(;
     job_name = "RA_example",
-    filename = joinpath(ma_dir, "test", "rep_workload.jl"), # requires use of Profile.jl
+    run_cmd = `$(Base.julia_cmd()) --project --track-allocation=all $(joinpath(ma_dir, "test", "rep_workload.jl"))`,
+    deps_to_monitor = [ReportMetrics],
     dirs_to_monitor = [joinpath(ma_dir, "test")],
+    process_filename = x -> replace(x, dirname(ma_dir) => ""),
 )
 ```
 
@@ -35,11 +38,11 @@ prints out:
 
 ```julia
 [ Info: RA_example: Number of unique allocating sites: 2
-┌───────────────────┬─────────────┬─────────────────────────────────────────────┐
-│     Allocations % │ Allocations │                        <file>:<line number> │
-│ (alloc_i/∑allocs) │       (KiB) │                                             │
-├───────────────────┼─────────────┼─────────────────────────────────────────────┤
-│          0.606143 │      468718 │ ReportMetrics.jl/test/rep_workload.jl:9 │
-│          0.393857 │      304562 │ ReportMetrics.jl/test/rep_workload.jl:8 │
-└───────────────────┴─────────────┴─────────────────────────────────────────────┘
+┌───────────────────┬─────────────┬─────────────────────────────────────────┐
+│     Allocations % │ Allocations │                    <file>:<line number> │
+│ (alloc_i/∑allocs) │       (KiB) │                                         │
+├───────────────────┼─────────────┼─────────────────────────────────────────┤
+│                77 │        7809 │ ReportMetrics.jl/test/rep_workload.jl:7 │
+│                23 │        2331 │ ReportMetrics.jl/test/rep_workload.jl:6 │
+└───────────────────┴─────────────┴─────────────────────────────────────────┘
 ```

--- a/test/Project.toml
+++ b/test/Project.toml
@@ -1,4 +1,3 @@
 [deps]
 Profile = "9abbd945-dff8-562f-b5e8-e1ebf5ef1b79"
-SpecialFunctions = "276daf66-3868-5448-9aa4-cd146d93841b"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"

--- a/test/rep_workload.jl
+++ b/test/rep_workload.jl
@@ -1,19 +1,10 @@
 import Profile
-import SpecialFunctions
-
-# We're overloading `SpecialFunctions.erf` in this
-# absurd way to force allocations in SpecialFunctions
-# so to make the report more interesting looking
-function SpecialFunctions.erf(x::Float64, y::Float64)
-    a = rand(3,3)
-    return a[1]
-end
 x = rand(1000)
 
 function foo()
     s = 0.0
     for i in x
-        s += i - SpecialFunctions.erf(rand(), rand())
+        s += i - rand()
     end
     return s
 end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,5 +1,4 @@
 import ReportMetrics
-import SpecialFunctions
 using Test
 
 ma_dir = ReportMetrics.mod_dir(ReportMetrics)
@@ -7,9 +6,9 @@ ma_dir = ReportMetrics.mod_dir(ReportMetrics)
 @testset "ReportMetrics" begin
     ReportMetrics.report_allocs(;
         job_name = "RA_example",
-        filename = joinpath(ma_dir, "test", "rep_workload.jl"), # requires use of Profile.jl
-        deps_to_monitor = [ReportMetrics, SpecialFunctions],
+        run_cmd = `$(Base.julia_cmd()) --project --track-allocation=all $(joinpath(ma_dir, "test", "rep_workload.jl"))`,
+        deps_to_monitor = [ReportMetrics],
         dirs_to_monitor = [joinpath(ma_dir, "test")],
-        n_unique_allocs = 10,
+        process_filename = x -> replace(x, dirname(ma_dir) => ""),
     )
 end


### PR DESCRIPTION
This PR changes the interface so that
 - Users must pass in `run_cmd`, since this will make the actual launch process more clear
 - Replace the `splitbys` argument by a function, `process_filename`, which defaults to an internal `process_filename_default`.

This should allow us to hack the string processing more easily for different cases, so that the table doesn't become crazy wide.