### PR TITLE
Avoid potential division by zero

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "ReportMetrics"
 uuid = "c1654acf-408b-4272-96ce-66c258df8a6c"
 authors = ["Charles Kawczynski <kawczynski.charles@gmail.com>"]
-version = "0.2.0"
+version = "0.2.1"
 
 [deps]
 Coverage = "a2441757-f6aa-5fb2-8edb-039e3f45d037"

--- a/README.md
+++ b/README.md
@@ -40,9 +40,9 @@ prints out:
 [ Info: RA_example: Number of unique allocating sites: 2
 ┌───────────────────┬─────────────┬─────────────────────────────────────────┐
 │     Allocations % │ Allocations │                    <file>:<line number> │
-│ (alloc_i/∑allocs) │       (KiB) │                                         │
+│ (alloc_i/∑allocs) │     (bytes) │                                         │
 ├───────────────────┼─────────────┼─────────────────────────────────────────┤
-│                77 │        7809 │ ReportMetrics.jl/test/rep_workload.jl:7 │
-│                23 │        2331 │ ReportMetrics.jl/test/rep_workload.jl:6 │
+│                77 │     7996800 │ ReportMetrics.jl/test/rep_workload.jl:7 │
+│                23 │     2387200 │ ReportMetrics.jl/test/rep_workload.jl:6 │
 └───────────────────┴─────────────┴─────────────────────────────────────────┘
 ```


### PR DESCRIPTION
This PR:
 - Fixes a bug where we potentially divide by zero
 - Change output format to bytes, instead of KiB, to avoid rounding to zero
 - Adds a kwarg, `suppress_url`, to supress using urls in the output table (I suspect they're causing issues in the output when trying this on buildkite with other packages)
 - bumps the patch version