### PR TITLE
Bump down patch version

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "ReportMetrics"
 uuid = "c1654acf-408b-4272-96ce-66c258df8a6c"
 authors = ["Charles Kawczynski <kawczynski.charles@gmail.com>"]
-version = "0.2.3"
+version = "0.2.2"
 
 [deps]
 Coverage = "a2441757-f6aa-5fb2-8edb-039e3f45d037"


### PR DESCRIPTION
I accidentally bumped the patch version twice, so the last attempt to register failed. Is this the easiest thing to do? Registering from this commit will result in a release with commits up to, and including this commit, correct?