### PR TITLE
Improve names, indicate when truncated

### DIFF
--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -20,4 +20,13 @@ ma_dir = ReportMetrics.mod_dir(ReportMetrics)
         process_filename = x -> replace(x, dirname(ma_dir) => ""),
         write_csv = true,
     )
+
+    ReportMetrics.report_allocs(;
+        job_name = "RA_example",
+        run_cmd = `$(Base.julia_cmd()) --project --track-allocation=all $(joinpath(ma_dir, "test", "rep_workload.jl"))`,
+        deps_to_monitor = [ReportMetrics],
+        dirs_to_monitor = [joinpath(ma_dir, "test")],
+        process_filename = x -> replace(x, dirname(ma_dir) => ""),
+        n_unique_allocs = 1,
+    )
 end


### PR DESCRIPTION
This PR improves some names, and adds an indicator when the output table is truncated.

I think this closes #8. Technically we could filter all of the allocations to report a fully accurate number, but I think users will typically want to truncate the table